### PR TITLE
Workshop deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,9 @@ LazyData: true
 RoxygenNote: 7.2.3
 Suggests: 
     janitor,
-    readr
+    readr,
+    testthat (>= 3.0.0)
 Depends: 
     R (>= 2.10)
+Config/testthat/edition: 3
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,9 +22,10 @@ LazyData: true
 RoxygenNote: 7.2.3
 Suggests: 
     janitor,
+    pkgload,
     readr,
+    shinytest2,
     testthat (>= 3.0.0)
 Depends: 
     R (>= 2.10)
 Config/testthat/edition: 3
-


### PR DESCRIPTION
Adds testthat, shinytest2 and pkgload to the suggested dependencies of the project.
This should ensure all dependencies for the workshop are present on workbench when the app/package is installed.